### PR TITLE
MARP-2668 Pattern demo Sanitize file name

### DIFF
--- a/pattern-demos-zip/src/com/axonivy/demo/patterndemos/zip/service/ZipService.java
+++ b/pattern-demos-zip/src/com/axonivy/demo/patterndemos/zip/service/ZipService.java
@@ -85,12 +85,17 @@ public class ZipService {
 		// iterates over entries in the zip file
 		while (entry != null) {
 			String filePath = destDirectory + java.io.File.separator + entry.getName();
+			java.nio.file.Path normalizedFilePath = Paths.get(filePath).normalize();
+			java.nio.file.Path normalizedDestDir = Paths.get(destDirectory).toAbsolutePath().normalize();
+			if (!normalizedFilePath.startsWith(normalizedDestDir)) {
+				throw new IOException("Bad zip entry: " + entry.getName());
+			}
 			if (!entry.isDirectory()) {
 				// if the entry is a file, extracts it
-				extractFile(zipIn, filePath);
+				extractFile(zipIn, normalizedFilePath.toString());
 			} else {
 				// if the entry is a directory, make the directory
-				var dir = new java.io.File(filePath);
+				var dir = new java.io.File(normalizedFilePath.toString());
 				dir.mkdir();
 			}
 			zipIn.closeEntry();

--- a/pattern-demos-zip/src/com/axonivy/demo/patterndemos/zip/service/ZipService.java
+++ b/pattern-demos-zip/src/com/axonivy/demo/patterndemos/zip/service/ZipService.java
@@ -85,8 +85,8 @@ public class ZipService {
 		// iterates over entries in the zip file
 		while (entry != null) {
 			String filePath = destDirectory + java.io.File.separator + entry.getName();
-			java.nio.file.Path normalizedFilePath = Paths.get(filePath).normalize();
-			java.nio.file.Path normalizedDestDir = Paths.get(destDirectory).toAbsolutePath().normalize();
+			Path normalizedFilePath = Paths.get(filePath).normalize();
+			Path normalizedDestDir = Paths.get(destDirectory).toAbsolutePath().normalize();
 			if (!normalizedFilePath.startsWith(normalizedDestDir)) {
 				throw new IOException("Bad zip entry: " + entry.getName());
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/axonivy-market/pattern-demos/security/code-scanning/6](https://github.com/axonivy-market/pattern-demos/security/code-scanning/6)

To fix the issue, we need to validate the constructed file paths to ensure they remain within the intended destination directory. This can be achieved by normalizing the paths and checking that the normalized path starts with the destination directory's normalized path. If the validation fails, the code should throw an exception or skip the entry.

Steps to fix:
1. Normalize the `filePath` using `java.nio.file.Path.normalize()` or `java.io.File.getCanonicalPath()`.
2. Verify that the normalized `filePath` starts with the normalized destination directory path.
3. If the validation fails, throw an exception or skip processing the entry.

The changes will be applied to the `unzip` method, specifically around the construction and usage of `filePath`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
